### PR TITLE
商品一覧表示＆ダミー画像の条件分岐

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except:[:index]
+  before_action :authenticate_user!, except: [:index]
   def index
-    @item = Item.order('created_at DESC')
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,7 +17,7 @@ class Item < ApplicationRecord
   validates :postage_id, presence: true
   validates :prefecture_id, presence: true
   validates :day_ship_id, presence: true
-  validates :price, presence: true, numericality: { greater_than: 299, less_than: 10000000 }
+  validates :price, presence: true, numericality: { greater_than: 299, less_than: 10_000_000 }
   validates :category_id, numericality: { other_than: 0 }
   validates :condition_id, numericality: { other_than: 0 }
   validates :postage_id, numericality: { other_than: 0 }

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,14 +123,15 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', "@item", class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
+        <% @items.each do |item|%>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +154,11 @@
         </div>
         <% end %>
       </li>
+      <%end%>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.empty?%>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,6 +176,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,10 +126,11 @@
     <%= link_to '新規投稿商品', "@item", class: "subtitle" %>
     <ul class='item-lists'>
 
+
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+        <% @items.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
-        <% @items.each do |item|%>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-   resources :items, only: [:index,:new,:create]
+   resources :items, only: [:index,:new,:create,]
 end


### PR DESCRIPTION
what・　商品が一覧ページに表示されるようにした。
商品がない時はダミー画像が表示されるようにした。

why・投稿した商品をみんなが見れるようにするため
・商品がない時の例を出すため

ログインしていない人が商品を見れるようにしている、新しい順https://gyazo.com/c8eaef4d01780c18cfd93ed4520122d2